### PR TITLE
fix: multiple spaces are not recognized inside project name wizard

### DIFF
--- a/src/Classes/Core/Ui/ProjectNameInputWizard.ts
+++ b/src/Classes/Core/Ui/ProjectNameInputWizard.ts
@@ -178,7 +178,7 @@ export class ProjectNameInputWizard
     {
         input = input.trim().toLowerCase().replace(/\s+/g, ' ');
         input = input.replace(/ä/g, 'ae').replace(/ö/g, 'oe').replace(/ü/g, 'ue').replace(/ß/g, 'ss');
-        input = input.replace(/\s/, '_');
+        input = input.replace(/\s/g, '_');
         return input;
     }
     


### PR DESCRIPTION
Inside the project name wizard, multiple spaces at a folder would lead to project names like `my_example folder-test-test`. This pull-request fixes this behavior. 