### PR TITLE
Allow setting protocol on lab open

### DIFF
--- a/src/Classes/Command/DockerComposeOpenCommand.ts
+++ b/src/Classes/Command/DockerComposeOpenCommand.ts
@@ -34,7 +34,7 @@ export class DockerComposeOpenCommand
             }
             
             const domain = app.env.get('APP_DOMAIN', app.env.get('APP_IP'));
-            const protocol = app.env.get('APP_PROTOCOL', 'http://');
+            const protocol = app.env.get('APP_PROTOCOL', cmd.protocol);
             const url = protocol + domain;
             
             console.log('Opening website "' + url + '" in your default browser!');

--- a/src/Classes/Command/DockerComposeOpenCommand.ts
+++ b/src/Classes/Command/DockerComposeOpenCommand.ts
@@ -34,7 +34,7 @@ export class DockerComposeOpenCommand
             }
             
             const domain = app.env.get('APP_DOMAIN', app.env.get('APP_IP'));
-            const protocol = app.env.get('APP_PROTOCOL', cmd.protocol);
+            const protocol = app.env.get('APP_PROTOCOL', `${cmd.protocol}://`);
             const url = protocol + domain;
             
             console.log('Opening website "' + url + '" in your default browser!');

--- a/src/Classes/Core/Command/DefaultCommands.ts
+++ b/src/Classes/Core/Command/DefaultCommands.ts
@@ -143,7 +143,14 @@ export class DefaultCommands
         
         context.commandRegistry.registerCommand('open', '../../Command/DockerComposeOpenCommand', {
             description: 'opens the current apps main container in your default browser window',
-            platforms: {windows: true, darwin: true, linux: true}
+            platforms: {windows: true, darwin: true, linux: true},
+            options: [
+                {
+                    definition: '-p, --protocol <protocol>',
+                    description: 'used to define the protocol to use',
+                    default: 'https'
+                }
+            ]
         });
         
         context.commandRegistry.registerCommand('stop-all', '../../Command/DockerStopAllContainersCommand', {


### PR DESCRIPTION
With this pull request it will be possible to set the protocol on `lab up` e.g. `lab up --protocol http` or `lab up -p http`. I also set the default to https, so from now on `lab open` will open all apps in https.